### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Description
+# Description
 
 This is Stratum Proxy for Ethereum based pools (RPCv2) using asynchronous networking written in Python Twisted.
 Originally developed for DwarfPool http://dwarfpool.com/eth
@@ -6,7 +6,7 @@ Originally developed for DwarfPool http://dwarfpool.com/eth
 **NOTE:** This fork is still in development. Some features may be broken. Please report any broken features or issues.
 
 
-#Features
+# Features
 
 * Additional up to 20% increase of earning compared to standard pools
 * ETH stratum proxy
@@ -19,7 +19,7 @@ Originally developed for DwarfPool http://dwarfpool.com/eth
 * Bypass worker_id for detailed statistic and per rig monitoring
 * pass submitHashrate to pool
 
-#How it works
+# How it works
 ```
    Pool A <---+                        +-------------+ Rig1 / PC1
  (Active)      |                       |
@@ -32,22 +32,22 @@ Originally developed for DwarfPool http://dwarfpool.com/eth
                                        +-------------+ Leaserigs
 ```
 
-#ToDo
+# ToDo
 
 * ---
 
 
-#Configuration
+# Configuration
 
 * all configs in file  eth-proxy.conf
 
 
-#Command line to miner start, recommended farm-recheck to use with stratum-proxy is 200
+# Command line to miner start, recommended farm-recheck to use with stratum-proxy is 200
 
 * ./ethminer --farm-recheck 200 -G -F http://127.0.0.1:8080/rig1
 
 
-#External script to restart proxy (made by rain)
+# External script to restart proxy (made by rain)
 
 * https://paste.ubuntu.com/15327007/
 
@@ -59,12 +59,12 @@ Originally developed for DwarfPool http://dwarfpool.com/eth
 * If not then mostly case that you have application running on this port, at example Antivirus.
 
 
-#Donations
+# Donations
 
 * ETH:  0xea7263feb7d8a8ab0a11eedd8f1ce04412ab0820
 
 
-#Requirements
+# Requirements
 
 eth-proxy is built in python. I have been testing it with 2.7.3, but it should work with other versions. The requirements for running the software are below.
 
@@ -72,7 +72,7 @@ eth-proxy is built in python. I have been testing it with 2.7.3, but it should w
 * python-twisted
 
 
-#Installation and start
+# Installation and start
 
 * [Linux]
 1) install twisted
@@ -117,15 +117,15 @@ http://sourceforge.net/projects/pywin32/files/pywin32/
   python xmr-proxy.py
 ```
 
-#Contact
+# Contact
 
 * I am available via admin@dwarfpool.com
 
-#Credits
+# Credits
 
 * Original version by Slush0 (original stratum code)
 * More Features added by GeneralFault, Wadee Womersley and Moopless
 
-#License
+# License
 
 * This software is provides AS-IS without any warranties of any kind. Please use at your own risk.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
